### PR TITLE
Fix Minigame not ending properly

### DIFF
--- a/src/com/pauldavdesign/mineauz/minigames/PlayerData.java
+++ b/src/com/pauldavdesign/mineauz/minigames/PlayerData.java
@@ -542,6 +542,8 @@ public class PlayerData {
 		List<MinigamePlayer> w = new ArrayList<MinigamePlayer>();
 		List<MinigamePlayer> l = new ArrayList<MinigamePlayer>();
 		w.add(player);
+		l.addAll(player.getMinigame().getPlayers());
+		l.remove(player);
 		endMinigame(player.getMinigame(), w, l);
 	}
 	


### PR DESCRIPTION
This fixes the bug where a multiplayer minigame ended with the score command doesn't end properly. The problem was that it didn't get who lost so any losers would not be exited from the game.
