### PR TITLE
Changed Minigames pom version to remove build number from pom version

### DIFF
--- a/Minigames/plugin.yml
+++ b/Minigames/plugin.yml
@@ -1,6 +1,6 @@
 name: Minigames
 main: au.com.mineauz.minigames.Minigames
-version: ${project.version}
+version: ${version.build}
 author: _Razz_
 softdepend: ['Multiverse-Core']
 

--- a/Minigames/pom.xml
+++ b/Minigames/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>au.com.mineauz</groupId>
     <artifactId>MinigamesProject</artifactId>
-    <version>1.7.0-b${env.BUILD_NUMBER}</version>
+    <version>1.7.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
   <artifactId>Minigames</artifactId>

--- a/Regions/plugin.yml
+++ b/Regions/plugin.yml
@@ -1,5 +1,5 @@
 name: Minigames-Regions
 main: au.com.mineauz.minigamesregions.Main
-version: ${project.version}
+version: ${version.build}
 author: _Razz_
 depend: ['Minigames']

--- a/Regions/pom.xml
+++ b/Regions/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>au.com.mineauz</groupId>
     <artifactId>MinigamesProject</artifactId>
-    <version>1.7.0-b${env.BUILD_NUMBER}</version>
+    <version>1.7.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
   <artifactId>Minigames-Regions</artifactId>
@@ -48,7 +48,7 @@
     <dependency>
       <groupId>au.com.mineauz</groupId>
       <artifactId>Minigames</artifactId>
-      <version>1.7.0-b${env.BUILD_NUMBER}</version>
+      <version>1.7.0-SNAPSHOT</version>
     </dependency>
   </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>au.com.mineauz</groupId>
   <artifactId>MinigamesProject</artifactId>
-  <version>1.7.0-b${env.BUILD_NUMBER}</version> <!-- ${env.BUILD_NUMBER} -->
+  <version>1.7.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>MinigamesProject</name>
   <url>http://dev.bukkit.org/server-mods/minigames/</url>


### PR DESCRIPTION
- This fixes dependency resolving issues for any project using Minigames
- plugin.yml versions and jar names are still the same
