### PR TITLE
Fixed null message on death

### DIFF
--- a/Minigames/src/au/com/mineauz/minigames/Events.java
+++ b/Minigames/src/au/com/mineauz/minigames/Events.java
@@ -76,7 +76,7 @@ public class Events implements Listener{
 			}
 			String msg = "";
 			msg = event.getDeathMessage();
-			event.setDeathMessage(null);
+			event.setDeathMessage("");
 			event.setDroppedExp(0);
 			
 			ply.addDeath();


### PR DESCRIPTION
Fixed a bug, where the death message would display "null" instead of nothing