### PR TITLE
Don't include players Prefix in scoreboard top signs

### DIFF
--- a/Minigames/src/au/com/mineauz/minigames/minigame/ScoreboardDisplay.java
+++ b/Minigames/src/au/com/mineauz/minigames/minigame/ScoreboardDisplay.java
@@ -189,12 +189,12 @@ public class ScoreboardDisplay {
 		Preconditions.checkArgument(stats.length >= 1 && stats.length <= 2);
 		
 		Sign sign = (Sign)block.getState();
-		sign.setLine(0, MinigameUtils.limitIgnoreCodes(ChatColor.GREEN + String.valueOf(place) + ". " + ChatColor.BLACK + stats[0].getPlayerDisplayName(), 15));
+		sign.setLine(0, MinigameUtils.limitIgnoreCodes(ChatColor.GREEN + String.valueOf(place) + ". " + ChatColor.BLACK + stats[0].getPlayerName(), 15));
 		sign.setLine(1, MinigameUtils.limitIgnoreCodes(ChatColor.BLUE + stat.displayValueSign(stats[0].getValue(), settings), 15));
 		
 		if (stats.length == 2) {
 			++place;
-			sign.setLine(2, MinigameUtils.limitIgnoreCodes(ChatColor.GREEN + String.valueOf(place) + ". " + ChatColor.BLACK + stats[1].getPlayerDisplayName(), 15));
+			sign.setLine(2, MinigameUtils.limitIgnoreCodes(ChatColor.GREEN + String.valueOf(place) + ". " + ChatColor.BLACK + stats[1].getPlayerName(), 15));
 			sign.setLine(3, MinigameUtils.limitIgnoreCodes(ChatColor.BLUE + stat.displayValueSign(stats[1].getValue(), settings), 15));
 		} else {
 			sign.setLine(2, "");


### PR DESCRIPTION
The signs have a short line-width, including the full display name doesn't allow the Nick to fit