### PR TITLE
Add config option to use usernames over display names

### DIFF
--- a/Minigames/config.yml
+++ b/Minigames/config.yml
@@ -1,5 +1,6 @@
 saveInventory: true
 requireEmptyInventory: false
+useDisplayNames: true
 
 treasurehunt:
   waittime: 3600

--- a/Minigames/src/au/com/mineauz/minigames/PlayerData.java
+++ b/Minigames/src/au/com/mineauz/minigames/PlayerData.java
@@ -52,6 +52,7 @@ import au.com.mineauz.minigames.stats.StoredGameStats;
 
 public class PlayerData {
 	private Map<String, MinigamePlayer> minigamePlayers = new HashMap<String, MinigamePlayer>();
+	private boolean useDisplayNames = Minigames.plugin.getConfig().getBoolean("useDisplayNames");
 	
 	private boolean partyMode = false;
 	
@@ -695,9 +696,13 @@ public class PlayerData {
 				else{
 					if(winners.size() == 1){
 						String score = "";
-						if(winners.get(0).getScore() != 0)
+						if(winners.get(0).getScore() != 0) {
 							score = MinigameUtils.formStr("player.end.broadcastScore", winners.get(0).getScore());
-						MinigameUtils.broadcast(MinigameUtils.formStr("player.end.broadcastMsg", winners.get(0).getDisplayName(), minigame.getName(true)) + ". " + score, minigame, ChatColor.GREEN);
+						}
+						if(useDisplayNames)	
+							MinigameUtils.broadcast(MinigameUtils.formStr("player.end.broadcastMsg", winners.get(0).getDisplayName(), minigame.getName(true)) + ". " + score, minigame, ChatColor.GREEN);
+						else
+							MinigameUtils.broadcast(MinigameUtils.formStr("player.end.broadcastMsg", winners.get(0).getName(), minigame.getName(true)) + ". " + score, minigame, ChatColor.GREEN);
 					}
 					else if(winners.size() > 1){
 						String win = "";
@@ -711,7 +716,13 @@ public class PlayerData {
 						
 						for(MinigamePlayer pl : winners){
 							if(winners.indexOf(pl) < 2){
-								win += pl.getDisplayName();
+								
+								if(useDisplayNames)
+									win += pl.getDisplayName();
+								else
+									win += pl.getName();
+								
+								
 								if(winners.indexOf(pl) + 2 >= winners.size()){
 									win += " and ";
 								}

--- a/Minigames/src/au/com/mineauz/minigames/commands/ScoreboardCommand.java
+++ b/Minigames/src/au/com/mineauz/minigames/commands/ScoreboardCommand.java
@@ -25,6 +25,7 @@ import au.com.mineauz.minigames.stats.StoredStat;
 
 public class ScoreboardCommand implements ICommand{
 	private Minigames plugin = Minigames.plugin;
+	private boolean useDisplayNames = Minigames.plugin.getConfig().getBoolean("useDisplayNames");
 
 	@Override
 	public String getName() {
@@ -164,7 +165,10 @@ public class ScoreboardCommand implements ICommand{
 			public void onSuccess(List<StoredStat> result) {
 				sender.sendMessage(ChatColor.GREEN + minigame.getName(true) + " Scoreboard: " + settings.getDisplayName() + " - " + fField.getTitle() + " " + fOrder.toString().toLowerCase());
 				for (StoredStat playerStat : result) {
-					sender.sendMessage(ChatColor.AQUA + playerStat.getPlayerDisplayName() + ": " + ChatColor.WHITE + stat.displayValue(playerStat.getValue(), settings));
+					if(useDisplayNames)
+						sender.sendMessage(ChatColor.AQUA + playerStat.getPlayerDisplayName() + ": " + ChatColor.WHITE + stat.displayValue(playerStat.getValue(), settings));
+					else
+						sender.sendMessage(ChatColor.AQUA + playerStat.getPlayerName() + ": " + ChatColor.WHITE + stat.displayValue(playerStat.getValue(), settings));
 				}
 			}
 			

--- a/Minigames/src/au/com/mineauz/minigames/mechanics/TreasureHuntMechanic.java
+++ b/Minigames/src/au/com/mineauz/minigames/mechanics/TreasureHuntMechanic.java
@@ -21,6 +21,7 @@ import org.bukkit.inventory.ItemStack;
 import au.com.mineauz.minigames.MinigamePlayer;
 import au.com.mineauz.minigames.MinigameTimer;
 import au.com.mineauz.minigames.MinigameUtils;
+import au.com.mineauz.minigames.Minigames;
 import au.com.mineauz.minigames.events.MinigameTimerTickEvent;
 import au.com.mineauz.minigames.events.TimerExpireEvent;
 import au.com.mineauz.minigames.gametypes.MinigameType;
@@ -33,6 +34,8 @@ import au.com.mineauz.minigames.minigame.reward.RewardsModule;
 import au.com.mineauz.minigames.minigame.reward.scheme.StandardRewardScheme;
 
 public class TreasureHuntMechanic extends GameMechanicBase{
+	
+	private boolean useDisplayNames = Minigames.plugin.getConfig().getBoolean("useDisplayNames");
 
 	@Override
 	public String getMechanic() {
@@ -365,10 +368,12 @@ public class TreasureHuntMechanic extends GameMechanicBase{
 							int z1 = thm.getTreasureLocation().getBlockZ();
 							int z2 = cblock.getLocation().getBlockZ();
 							if(x2 == x1 && y2 == y1 && z2 == z1){
-								MinigameUtils.broadcast(MinigameUtils.formStr("minigame.treasurehunt.plyFound", 
-										event.getPlayer().getDisplayName(), 
-										minigame.getName(true)), minigame, 
-										"minigame.treasure.announce");
+								
+								if(useDisplayNames)
+									MinigameUtils.broadcast(MinigameUtils.formStr("minigame.treasurehunt.plyFound", event.getPlayer().getDisplayName(), minigame.getName(true)), minigame, "minigame.treasure.announce");
+								else
+									MinigameUtils.broadcast(MinigameUtils.formStr("minigame.treasurehunt.plyFound", event.getPlayer().getName(), minigame.getName(true)), minigame, "minigame.treasure.announce");
+								
 								event.setCancelled(true);
 								Chest chest = (Chest) cblock.getState();
 								event.getPlayer().openInventory(chest.getInventory());

--- a/Minigames/src/au/com/mineauz/minigames/minigame/ScoreboardDisplay.java
+++ b/Minigames/src/au/com/mineauz/minigames/minigame/ScoreboardDisplay.java
@@ -47,6 +47,7 @@ public class ScoreboardDisplay {
 	private int width;
 	private int height;
 	private BlockFace facing;
+	private boolean useDisplayNames = Minigames.plugin.getConfig().getBoolean("useDisplayNames");
 	
 	private StatSettings settings;
 	
@@ -189,12 +190,18 @@ public class ScoreboardDisplay {
 		Preconditions.checkArgument(stats.length >= 1 && stats.length <= 2);
 		
 		Sign sign = (Sign)block.getState();
-		sign.setLine(0, MinigameUtils.limitIgnoreCodes(ChatColor.GREEN + String.valueOf(place) + ". " + ChatColor.BLACK + stats[0].getPlayerDisplayName(), 15));
+		if(useDisplayNames)
+			sign.setLine(0, MinigameUtils.limitIgnoreCodes(ChatColor.GREEN + String.valueOf(place) + ". " + ChatColor.BLACK + stats[0].getPlayerDisplayName(), 15));
+		else
+			sign.setLine(0, MinigameUtils.limitIgnoreCodes(ChatColor.GREEN + String.valueOf(place) + ". " + ChatColor.BLACK + stats[0].getPlayerName(), 15));
 		sign.setLine(1, MinigameUtils.limitIgnoreCodes(ChatColor.BLUE + stat.displayValueSign(stats[0].getValue(), settings), 15));
 		
 		if (stats.length == 2) {
 			++place;
-			sign.setLine(2, MinigameUtils.limitIgnoreCodes(ChatColor.GREEN + String.valueOf(place) + ". " + ChatColor.BLACK + stats[1].getPlayerDisplayName(), 15));
+			if(useDisplayNames)
+				sign.setLine(2, MinigameUtils.limitIgnoreCodes(ChatColor.GREEN + String.valueOf(place) + ". " + ChatColor.BLACK + stats[1].getPlayerDisplayName(), 15));
+			else
+				sign.setLine(2, MinigameUtils.limitIgnoreCodes(ChatColor.GREEN + String.valueOf(place) + ". " + ChatColor.BLACK + stats[1].getPlayerName(), 15));
 			sign.setLine(3, MinigameUtils.limitIgnoreCodes(ChatColor.BLUE + stat.displayValueSign(stats[1].getValue(), settings), 15));
 		} else {
 			sign.setLine(2, "");

--- a/Minigames/src/au/com/mineauz/minigames/minigame/modules/JuggernautModule.java
+++ b/Minigames/src/au/com/mineauz/minigames/minigame/modules/JuggernautModule.java
@@ -14,6 +14,7 @@ import au.com.mineauz.minigames.minigame.Minigame;
 public class JuggernautModule extends MinigameModule{
 	
 	private MinigamePlayer juggernaut = null;
+	private boolean useDisplayNames = Minigames.plugin.getConfig().getBoolean("useDisplayNames");
 
 	public JuggernautModule(Minigame mgm) {
 		super(mgm);
@@ -66,8 +67,11 @@ public class JuggernautModule extends MinigameModule{
 			player.getMinigame().getScoreboardManager().getTeam("juggernaut").addPlayer(player.getPlayer().getPlayer());
 			
 			juggernaut.sendMessage(MinigameUtils.getLang("player.juggernaut.plyMsg"), null);
-			Minigames.plugin.mdata.sendMinigameMessage(getMinigame(), 
-					MinigameUtils.formStr("player.juggernaut.gameMsg", juggernaut.getDisplayName()), null, juggernaut);
+			
+			if(useDisplayNames)
+				Minigames.plugin.mdata.sendMinigameMessage(getMinigame(), MinigameUtils.formStr("player.juggernaut.gameMsg", juggernaut.getDisplayName()), null, juggernaut);
+			else
+				Minigames.plugin.mdata.sendMinigameMessage(getMinigame(), MinigameUtils.formStr("player.juggernaut.gameMsg", juggernaut.getName()), null, juggernaut);
 			
 			LoadoutModule lm =LoadoutModule.getMinigameModule(getMinigame());
 			if(lm.hasLoadout("juggernaut")){

--- a/Minigames/src/au/com/mineauz/minigames/signs/TeamSign.java
+++ b/Minigames/src/au/com/mineauz/minigames/signs/TeamSign.java
@@ -16,6 +16,7 @@ import au.com.mineauz.minigames.minigame.modules.TeamsModule;
 public class TeamSign implements MinigameSign {
 	
 	private Minigames plugin = Minigames.plugin;
+	private boolean useDisplayNames = Minigames.plugin.getConfig().getBoolean("useDisplayNames");
 	
 	@Override
 	public String getName() {
@@ -77,7 +78,11 @@ public class TeamSign implements MinigameSign {
 								}
 								if(nt.getPlayers().size() - sm.getPlayers().size() < 1){
 									MultiplayerType.switchTeam(mgm, player, nt);
-									plugin.mdata.sendMinigameMessage(mgm, String.format(nt.getGameAssignMessage(), player.getDisplayName(), nt.getChatColor() + nt.getDisplayName()), null, player);
+									
+									if(useDisplayNames)
+										plugin.mdata.sendMinigameMessage(mgm, String.format(nt.getGameAssignMessage(), player.getDisplayName(), nt.getChatColor() + nt.getDisplayName()), null, player);
+									else
+										plugin.mdata.sendMinigameMessage(mgm, String.format(nt.getGameAssignMessage(), player.getName(), nt.getChatColor() + nt.getDisplayName()), null, player);
 									player.sendMessage(String.format(nt.getAssignMessage(), nt.getChatColor() + nt.getDisplayName()), null);
 								}
 								else{


### PR DESCRIPTION
Looking at pull request #62 I've tried to add a config option which allows server owners to use usernames instead of display names in scoreboards and mini game announcements. By default, the config is set to use display names.

I've not tested this, so it may need to be compiled and tested on your end. My maven is weird and often doesn't import all the libraries it needs to compile, so I wasn't able to export and test it. Sorry :/
