### PR TITLE
Properly fix #126

### DIFF
--- a/Regions/src/main/java/au/com/mineauz/minigamesregions/actions/AddScoreAction.java
+++ b/Regions/src/main/java/au/com/mineauz/minigamesregions/actions/AddScoreAction.java
@@ -69,7 +69,7 @@ public class AddScoreAction extends ActionInterface {
 	}
 
 	private void checkScore(MinigamePlayer player){
-		if(player.getMinigame().getMaxScorePerPlayer() >= player.getScore() || player.getTeam().getScore() >= player.getMinigame().getMaxScore()){
+		if(player.getMinigame().getMaxScorePerPlayer() <= player.getScore() || player.getTeam().getScore() >= player.getMinigame().getMaxScore()){
 			List<MinigamePlayer> w;
 			List<MinigamePlayer> l;
 			if(player.getMinigame().isTeamGame()){

--- a/Regions/src/main/java/au/com/mineauz/minigamesregions/actions/SetScoreAction.java
+++ b/Regions/src/main/java/au/com/mineauz/minigamesregions/actions/SetScoreAction.java
@@ -65,7 +65,7 @@ public class SetScoreAction extends ActionInterface {
 	}
 
 	private void checkScore(MinigamePlayer player){
-		if(player.getMinigame().getMaxScorePerPlayer() >= player.getScore() || player.getTeam().getScore() >= player.getMinigame().getMaxScore()){
+		if(player.getMinigame().getMaxScorePerPlayer() <= player.getScore() || player.getTeam().getScore() >= player.getMinigame().getMaxScore()){
 			List<MinigamePlayer> w;
 			List<MinigamePlayer> l;
 			if(player.getMinigame().isTeamGame()){


### PR DESCRIPTION
Tested several minigames using the `add score` function and all worked as expected. Games now properly end when players get the max number of points instead of ending whenever a player gets a point