### PR TITLE
Dependecy should be spigot-api

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
     <!-- Bukkit -->
     <dependency>
       <groupId>org.spigotmc</groupId>
-      <artifactId>spigot</artifactId>
+      <artifactId>spigot-api</artifactId>
       <version>1.12.1-R0.1-SNAPSHOT</version>
       <scope>provided</scope>
     </dependency>


### PR DESCRIPTION
I may be wrong on this, but every time I build the plugin locally I have to change the pom to this, otherwise the build fails.

If it is correct currently, could you explain why you use spigot instead of spigot-api, and how it works locally for you?