### PR TITLE
Fixes Issue AddstarMC#191

### DIFF
--- a/Minigames/src/main/java/au/com/mineauz/minigames/MinigamePlayerManager.java
+++ b/Minigames/src/main/java/au/com/mineauz/minigames/MinigamePlayerManager.java
@@ -580,6 +580,8 @@ public class MinigamePlayerManager {
 	
 	
 	public void endMinigame(Minigame minigame, List<MinigamePlayer> winners, List<MinigamePlayer> losers){
+		//When the minigame ends, the flag for recognizing the start teleportation needs to be resetted
+		minigame.setPlayersAtStart(false);
 		EndMinigameEvent event = new EndMinigameEvent(winners, losers, minigame);
 		Bukkit.getServer().getPluginManager().callEvent(event);
 		if (!event.isCancelled()) {


### PR DESCRIPTION
## Purpose
The teleportation to the start positions only worked for the first time. When replaying the minigame without restarting the server, players won't get teleported and stay in the lobby.

## Approach
After teleporting the players to their start positions, a flag in the minigame is set. This flag is not resetted after ending the minigame. This fix just does that.