### PR TITLE
Fix spleef preset parsing failure

### DIFF
--- a/Minigames/src/main/resources/presets/spleef.yml
+++ b/Minigames/src/main/resources/presets/spleef.yml
@@ -6,8 +6,8 @@ spleef:
   lives: 1
   loadouts:
     default:
-	  items:
-	    '0':
+      items:
+        '0':
           ==: org.bukkit.inventory.ItemStack
           type: DIAMOND_SPADE
   whitelistblocks:


### PR DESCRIPTION
## Purpose
Remove tabs in the space indented spleef.yml
This is not just a cosmetic change. Tabs are forbidden in YAML and cause parsing errors.
`Caused by: org.yaml.snakeyaml.scanner.ScannerException: while scanning for the next token                              
found character '\t(TAB)' that cannot start any token. (Do not use \t(TAB) for indentation)
 in 'string', line 9, column 1:                                                                                        
          items:                                                                                                       
    ^ `

## Approach
Tabs replaced with spaces