### PR TITLE
Randomization added into infected team balancing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@
 target
 .idea/
 *.iml
+
+#Eclipse
+.project
+.classpath

--- a/Minigames/src/main/java/au/com/mineauz/minigames/mechanics/InfectionMechanic.java
+++ b/Minigames/src/main/java/au/com/mineauz/minigames/mechanics/InfectionMechanic.java
@@ -46,7 +46,17 @@ public class InfectionMechanic extends GameMechanicBase {
     @Override
     public List<MinigamePlayer> balanceTeam(List<MinigamePlayer> players, Minigame minigame) {
         List<MinigamePlayer> result = new ArrayList<>();
-        for (MinigamePlayer ply : players) {
+
+        while (players.size() > 0) {
+        	
+        	//Generate random player index
+            int indexRandom = (int) (players.size() * Math.random());
+            
+            //In improbable case that index == players.size(), reduce index by 1
+            if (indexRandom == players.size()) indexRandom--;
+        	
+        	MinigamePlayer ply = players.remove(indexRandom);
+        	
             Team red = TeamsModule.getMinigameModule(minigame).getTeam(TeamColor.RED);
             Team blue = TeamsModule.getMinigameModule(minigame).getTeam(TeamColor.BLUE);
             Team team = ply.getTeam();

--- a/Minigames/src/main/java/au/com/mineauz/minigames/mechanics/InfectionMechanic.java
+++ b/Minigames/src/main/java/au/com/mineauz/minigames/mechanics/InfectionMechanic.java
@@ -51,11 +51,6 @@ public class InfectionMechanic extends GameMechanicBase {
             
             //Generate random player index
             int indexRandom = (int) (players.size() * Math.random());
-            
-            //In improbable case that index == players.size(), reduce index by 1
-            if (indexRandom == players.size()) {
-                indexRandom--;
-            }
                 
             MinigamePlayer ply = players.remove(indexRandom);
             

--- a/Minigames/src/main/java/au/com/mineauz/minigames/mechanics/InfectionMechanic.java
+++ b/Minigames/src/main/java/au/com/mineauz/minigames/mechanics/InfectionMechanic.java
@@ -48,15 +48,17 @@ public class InfectionMechanic extends GameMechanicBase {
         List<MinigamePlayer> result = new ArrayList<>();
 
         while (players.size() > 0) {
-        	
-        	//Generate random player index
+            
+            //Generate random player index
             int indexRandom = (int) (players.size() * Math.random());
             
             //In improbable case that index == players.size(), reduce index by 1
-            if (indexRandom == players.size()) indexRandom--;
-        	
-        	MinigamePlayer ply = players.remove(indexRandom);
-        	
+            if (indexRandom == players.size()) {
+                indexRandom--;
+            }
+                
+            MinigamePlayer ply = players.remove(indexRandom);
+            
             Team red = TeamsModule.getMinigameModule(minigame).getTeam(TeamColor.RED);
             Team blue = TeamsModule.getMinigameModule(minigame).getTeam(TeamColor.BLUE);
             Team team = ply.getTeam();


### PR DESCRIPTION
## Purpose
Infected did not have randomisation in the team balancing function. Players were assigned, in sequence, to red team if any spots were available. This lead to the first player(s) to join the lobby becoming infected.

## Approach
This fix has added a simple randomisation process in the team balancing function of infected. The result list order is changed from the randomisation although I haven't checked this functions uses and list order does not seem to have any affect. THIS CODE IS UNTESTED.
