### PR TITLE
Download "emptyResourcePack.zip" from master

### DIFF
--- a/Minigames/src/main/java/au/com/mineauz/minigames/managers/ResourcePackManager.java
+++ b/Minigames/src/main/java/au/com/mineauz/minigames/managers/ResourcePackManager.java
@@ -54,7 +54,7 @@ public class ResourcePackManager {
 
     private boolean loadEmptyPack() {
         try {
-            URL u = new URL("https://github.com/AddstarMC/Minigames/raw/resourcepack/Minigames/src/main/resources/resourcepack/emptyResourcePack.zip");
+            URL u = new URL("https://github.com/AddstarMC/Minigames/raw/master/Minigames/src/main/resources/resourcepack/emptyResourcePack.zip");
             ResourcePack empty = new ResourcePack("empty", u);
             addResourcePack(empty);
             return true;


### PR DESCRIPTION
Hello,
I get an HTTP error 404 when my server starts because your branch "resources" doesn't exists anymore.
```
[Craft Scheduler Thread - 6/WARN]: java.io.FileNotFoundException: https://github.com/AddstarMC/Minigames/raw/resourcepack/Minigames/src/main/resources/resourcepack/emptyResourcePack.zip
[Craft Scheduler Thread - 6/WARN]: 	at sun.net.www.protocol.http.HttpURLConnection.getInputStream0(HttpURLConnection.java:1896)
[Craft Scheduler Thread - 6/WARN]: 	at sun.net.www.protocol.http.HttpURLConnection.getInputStream(HttpURLConnection.java:1498)
[Craft Scheduler Thread - 6/WARN]: 	at sun.net.www.protocol.https.HttpsURLConnectionImpl.getInputStream(HttpsURLConnectionImpl.java:268)
[Craft Scheduler Thread - 6/WARN]: 	at java.net.URL.openStream(URL.java:1067)
[Craft Scheduler Thread - 6/WARN]: 	at au.com.mineauz.minigames.objects.ResourcePack.download(ResourcePack.java:231)
[Craft Scheduler Thread - 6/WARN]: 	at au.com.mineauz.minigames.objects.ResourcePack.lambda$validate$0(ResourcePack.java:163)
[Craft Scheduler Thread - 6/WARN]: 	at org.bukkit.craftbukkit.v1_16_R2.scheduler.CraftTask.run(CraftTask.java:81)
[Craft Scheduler Thread - 6/WARN]: 	at org.bukkit.craftbukkit.v1_16_R2.scheduler.CraftAsyncTask.run(CraftAsyncTask.java:54)
[Craft Scheduler Thread - 6/WARN]: 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
[Craft Scheduler Thread - 6/WARN]: 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
```
Here's the very little tiny fix. :D
Thanks, and have a nice day !