### PR TITLE
Fix custom language file loading ("minigames.properties")

### DIFF
--- a/Minigames/src/main/java/au/com/mineauz/minigames/managers/MessageManager.java
+++ b/Minigames/src/main/java/au/com/mineauz/minigames/managers/MessageManager.java
@@ -48,7 +48,7 @@ public class MessageManager {
     public static void registerCoreLanguage() {
         String tag = Minigames.getPlugin().getConfig().getString("lang", Locale.getDefault().toLanguageTag());
         locale = Locale.forLanguageTag(tag);
-        Minigames.log().info("MessageManager set locale for language:" + locale.toLanguageTag());
+        Minigames.log().info("MessageManager set locale for language: " + locale.toLanguageTag());
         File file = new File(new File(Minigames.getPlugin().getDataFolder(), "lang"), "minigames.properties");
         registerCoreLanguage(file, Locale.getDefault());
     }
@@ -94,8 +94,14 @@ public class MessageManager {
             return false;
         } else {
             if (propertiesHashMap.put(identifier, bundle) == null) {
-                logger.info("Loaded and registered Resource Bundle " + bundle.getBaseBundleName()
-                        + " with Locale:" + bundle.getLocale().toString() + " Added " + bundle.keySet().size() + " keys");
+                String bundleName = bundle.getBaseBundleName();
+                if ( bundleName == null ) bundleName = "custom";
+                Locale getLocale = bundle.getLocale();
+                String locale;
+                if ( getLocale == null ) locale = "unknown";
+                else locale = getLocale.toString();
+                logger.info("Loaded and registered Resource Bundle " + bundleName
+                        + " with Locale:" + locale + ", Added " + bundle.keySet().size() + " keys");
                 return true;
             } else {
                 return false;


### PR DESCRIPTION
Hello ! ^^
This commit fixes the loading of a custom language file (`minigames.properties`).
Otherwise, this error is thrown, and the plugin cannot start.
```
java.lang.NullPointerException
	at au.com.mineauz.minigames.managers.MessageManager.registerMessageFile(MessageManager.java:98)
	at au.com.mineauz.minigames.managers.MessageManager.registerCoreLanguage(MessageManager.java:69)
	at au.com.mineauz.minigames.managers.MessageManager.registerCoreLanguage(MessageManager.java:53)
	at au.com.mineauz.minigames.Minigames.onEnable(Minigames.java:224)
	at org.bukkit.plugin.java.JavaPlugin.setEnabled(JavaPlugin.java:263)
```
Have a nice day !