### PR TITLE
Improve MAVEN build Performance

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,7 @@
       <travis.commit>${env.TRAVIS_COMMIT}</travis.commit>
       <env.CODACY_API_TOKEN/>
       <argline/>
+  	<closeTestReports>true</closeTestReports>
   </properties>
   <developers>
     <developer>
@@ -193,6 +194,7 @@
               <configuration>
                       <!-- no argLine here -->
               </configuration>
+              	<disableXmlReport>${closeTestReports}</disableXmlReport>
           </plugin>
           <plugin>
               <groupId>org.jacoco</groupId>


### PR DESCRIPTION

That report generation takes time, slowing down the overall build. Reports are definitely useful, but do you need them every time you run the build. We can conditionally disable generating test reports by setting `<disableXmlReport>true<disableXmlReport>`. If you need to generate reports, just add `-DcloseTestReports=false` to the end of mvn build command.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
