### PR TITLE
Game objective message fix

### DIFF
--- a/Minigames/src/main/java/au/com/mineauz/minigames/MinigameMessageType.java
+++ b/Minigames/src/main/java/au/com/mineauz/minigames/MinigameMessageType.java
@@ -4,5 +4,6 @@ public enum MinigameMessageType {
     INFO,
     ERROR,
     WIN,
-    LOSS
+    LOSS,
+    NONE
 }

--- a/Minigames/src/main/java/au/com/mineauz/minigames/managers/MinigamePlayerManager.java
+++ b/Minigames/src/main/java/au/com/mineauz/minigames/managers/MinigamePlayerManager.java
@@ -90,10 +90,10 @@ public class MinigamePlayerManager {
 
         //Give them the objective
         if (minigame.getObjective() != null) {
-            player.sendInfoMessage(ChatColor.GREEN + "----------------------------------------------------");
+            player.sendUnprefixedMessage(ChatColor.GREEN + "----------------------------------------------------");
             player.sendInfoMessage(ChatColor.AQUA.toString() + ChatColor.BOLD + MinigameUtils.formStr("player.join.objective",
                     ChatColor.RESET.toString() + ChatColor.WHITE + minigame.getObjective()));
-            player.sendInfoMessage(ChatColor.GREEN + "----------------------------------------------------");
+            player.sendUnprefixedMessage(ChatColor.GREEN + "----------------------------------------------------");
         }
         //Prepare regeneration region for rollback.
         mgManager.addBlockRecorderData(minigame);

--- a/Minigames/src/main/java/au/com/mineauz/minigames/objects/MinigamePlayer.java
+++ b/Minigames/src/main/java/au/com/mineauz/minigames/objects/MinigamePlayer.java
@@ -129,6 +129,10 @@ public class MinigamePlayer implements ScriptObject {
         this.sendMessage(msg, MinigameMessageType.INFO);
     }
 
+    public void sendUnprefixedMessage(final String msg) {
+        this.sendMessage(msg, MinigameMessageType.NONE);
+    }
+
     public void sendMessage(final String msg, final @NotNull MinigameMessageType type) {
         String init = "";
         switch (type) {
@@ -140,6 +144,8 @@ public class MinigamePlayer implements ScriptObject {
                 break;
             case LOSS:
                 init = ChatColor.DARK_RED + "[Minigames] " + ChatColor.WHITE;
+                break;
+            case NONE:
                 break;
             case INFO:
             default:


### PR DESCRIPTION
### Purpose

Fixes a bug in which the [Minigames] prefix was displayed before each divider line above and below a game’s objective message. 