### PR TITLE
Fixing not visible tool-points

### DIFF
--- a/Minigames/src/main/java/au/com/mineauz/minigames/tool/EndPositionMode.java
+++ b/Minigames/src/main/java/au/com/mineauz/minigames/tool/EndPositionMode.java
@@ -58,7 +58,7 @@ public class EndPositionMode implements ToolMode {
     @Override
     public void select(MinigamePlayer player, Minigame minigame, Team team) {
         if (minigame.getEndPosition() != null) {
-            player.getPlayer().sendBlockChange(minigame.getEndPosition(), Material.SKELETON_SKULL, (byte) 1);
+            player.getPlayer().sendBlockChange(minigame.getEndPosition(), Material.SKELETON_SKULL.createBlockData());
             player.sendInfoMessage("Selected end position (marked with skull)");
         } else {
             player.sendMessage("No end position set!", MinigameMessageType.ERROR);

--- a/Minigames/src/main/java/au/com/mineauz/minigames/tool/LobbyPositionMode.java
+++ b/Minigames/src/main/java/au/com/mineauz/minigames/tool/LobbyPositionMode.java
@@ -58,7 +58,7 @@ public class LobbyPositionMode implements ToolMode {
     @Override
     public void select(MinigamePlayer player, Minigame minigame, Team team) {
         if (minigame.getLobbyPosition() != null) {
-            player.getPlayer().sendBlockChange(minigame.getLobbyPosition(), Material.SKELETON_SKULL, (byte) 1);
+            player.getPlayer().sendBlockChange(minigame.getLobbyPosition(), Material.SKELETON_SKULL.createBlockData());
             player.sendInfoMessage("Selected lobby position (marked with skull)");
         } else {
             player.sendMessage("No lobby position set!", MinigameMessageType.ERROR);

--- a/Minigames/src/main/java/au/com/mineauz/minigames/tool/QuitPositionMode.java
+++ b/Minigames/src/main/java/au/com/mineauz/minigames/tool/QuitPositionMode.java
@@ -58,7 +58,7 @@ public class QuitPositionMode implements ToolMode {
     @Override
     public void select(MinigamePlayer player, Minigame minigame, Team team) {
         if (minigame.getQuitPosition() != null) {
-            player.getPlayer().sendBlockChange(minigame.getQuitPosition(), Material.SKELETON_SKULL, (byte) 1);
+            player.getPlayer().sendBlockChange(minigame.getQuitPosition(), Material.SKELETON_SKULL.createBlockData());
             player.sendInfoMessage("Selected quit position (marked with skull)");
         } else {
             player.sendMessage("No quit position set!", MinigameMessageType.ERROR);

--- a/Minigames/src/main/java/au/com/mineauz/minigames/tool/SpectatorPositionMode.java
+++ b/Minigames/src/main/java/au/com/mineauz/minigames/tool/SpectatorPositionMode.java
@@ -58,7 +58,7 @@ public class SpectatorPositionMode implements ToolMode {
     @Override
     public void select(MinigamePlayer player, Minigame minigame, Team team) {
         if (minigame.getSpectatorLocation() != null) {
-            player.getPlayer().sendBlockChange(minigame.getSpectatorLocation(), Material.SKELETON_SKULL, (byte) 1);
+            player.getPlayer().sendBlockChange(minigame.getSpectatorLocation(), Material.SKELETON_SKULL.createBlockData());
             player.sendInfoMessage("Selected spectator position (marked with skull).");
         } else {
             player.sendMessage("No spectator position set!", MinigameMessageType.ERROR);

--- a/Minigames/src/main/java/au/com/mineauz/minigames/tool/StartPositionMode.java
+++ b/Minigames/src/main/java/au/com/mineauz/minigames/tool/StartPositionMode.java
@@ -116,13 +116,13 @@ public class StartPositionMode implements ToolMode {
     public void select(MinigamePlayer player, Minigame minigame, Team team) {
         if (team != null) {
             for (Location loc : team.getStartLocations()) {
-                player.getPlayer().sendBlockChange(loc, Material.SKELETON_SKULL, (byte) 1);
+                player.getPlayer().sendBlockChange(loc, Material.SKELETON_SKULL.createBlockData());
             }
             player.sendInfoMessage("Selected " + team.getChatColor() + team.getDisplayName() + ChatColor.WHITE +
                     " start points in " + minigame);
         } else {
             for (Location loc : minigame.getStartLocations()) {
-                player.getPlayer().sendBlockChange(loc, Material.SKELETON_SKULL, (byte) 1);
+                player.getPlayer().sendBlockChange(loc, Material.SKELETON_SKULL.createBlockData());
             }
             player.sendInfoMessage("Selected start points in " + minigame);
         }


### PR DESCRIPTION
When using /mg tool select, there were no skulls to indicate spawnpoints etc. 

Fixes #353 