### PR TITLE
How about add more Forked VM when run all tests in build

### DIFF
--- a/Minigames/pom.xml
+++ b/Minigames/pom.xml
@@ -207,7 +207,7 @@
                 <version>3.0.0-M3</version>
                 <configuration>
                     <skipTests>true</skipTests>
-                    <forkCount>1</forkCount>
+                    <forkCount>1.5C</forkCount>
                     <reuseForks>false</reuseForks>
                 </configuration>
             </plugin>


### PR DESCRIPTION

Maven will run all tests in a single forked VM by default. This can be problematic if there are a lot of tests or some very memory-hungry ones. We can fork more test VM by setting `<fork>1.5C</fork>`.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
